### PR TITLE
Fixed Slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [Babel Meeting Notes](https://github.com/babel/notes)
 - [Babel Website Repo](https://github.com/babel/website)
 - [Babel Twitter](https://twitter.com/babeljs)
-- [Slack sign-up](slack.babeljs.io)
+- [Slack sign-up](https://slack.babeljs.io)
 
 ## Links from the Talk
 


### PR DESCRIPTION
Fixed slack link which was redirecting to https://github.com/hzoo/so-how-does-babel-even-work/blob/master/slack.babeljs.io